### PR TITLE
Replace pkg_resources with importlib.

### DIFF
--- a/global_gender_predictor/global_gender_predictor.py
+++ b/global_gender_predictor/global_gender_predictor.py
@@ -1,7 +1,7 @@
 import json
 import gzip
 import hashlib
-from pkg_resources import resource_filename
+import importlib.resources
 
 
 def convert_prob_to_byte(gender, prob):
@@ -38,9 +38,9 @@ class GlobalGenderPredictor:
             # already loaded, don't try again
             return
 
-        data_path = resource_filename("global_gender_predictor", f"data/gender_wgnd2.{name_hash}.jsonl.gz")
+        ref = importlib.resources.files("global_gender_predictor") / f"data/gender_wgnd2.{name_hash}.jsonl.gz"
 
-        with gzip.open(data_path, 'rb') as f:
+        with importlib.resources.as_file(ref) as data_path, gzip.open(data_path, 'rb') as f:
             for line in f:
                 name_dict = json.loads(line)
                 max_gender = max(name_dict['gender_prob'], key=name_dict['gender_prob'].get)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 description = "Predict gender using first name using data from World Gender Name Dictionary 2.0."
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
[pkg_resources is deprecated as an API](https://setuptools.pypa.io/en/latest/pkg_resources.html). This PR replaces the use of `resource_filename` with [`importlib.resources.files(..)`](https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files).

**Background:** As of Python 3.12, setuptools is no longer included in new venvs. If you clone the repo, setup a venv, `pip install -e . pytest` and run `pytest` it'll throw `ModuleNotFoundError: No module named 'pkg_resources'`. If you manually install setuptools and re-run pytest, it'll throw the DeprecationWarning about pkg_resources.

**Additional Note:** Bumped `requires-python` to >=3.9 since this is when the new API was introduced and this is also the current minimum supported version of Python.